### PR TITLE
Adicionando mudança de chat

### DIFF
--- a/chat.sh
+++ b/chat.sh
@@ -2,19 +2,15 @@
 
 USERNAME=$1
 CHATS_PATH=$2
-CHAT_PANE_ID=$3
+CHAT=$3
 
-CHAT=$(nnn -p - ./chats/)
+tmux kill-pane -a
 
 tmux split-window -h "tail -f $CHAT"
-
-CHAT_PANE_ID=$(tmux display -p '#{pane_id}')
 
 tmux split-window -v "./message.sh $USERNAME $CHATS_PATH $CHAT"
 
 tmux send-keys "tmux resize-pane -L 60" Enter
 tmux send-keys "tmux resize-pane -D 10" Enter
 
-MESSAGE_PANE_ID=$(tmux display -p '#{pane_id}')
-
-./chat.sh $USERNAME $CHATS_PATH $CHATS_PANE_ID
+./main.sh

--- a/main.sh
+++ b/main.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/bash
 
 CHATS_PATH="./chats"
+CHAT=$(nnn -op - ./chats/)
 
-CHATS_PANE_ID=$(tmux display -p '#{pane_id}')
-
-./chat.sh $USERNAME $CHATS_PATH $CHATS_PANE_ID
+./chat.sh $USERNAME $CHATS_PATH $CHAT


### PR DESCRIPTION
## O que foi feito?
Foi adicionado um `tmux kill-panes -a` para limpar todas as telas antes de entrar em outro chat, sem precisar usar `Ctrl + C` para fechar o chat atual e evitar a duplicação de chats. 